### PR TITLE
implement getUserToken

### DIFF
--- a/api/token_handler.go
+++ b/api/token_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"time"
@@ -38,12 +39,18 @@ func (th *TokenHandler) HandleCreateToken(w http.ResponseWriter, r *http.Request
 
 	user, err := th.userStore.GetUserByName(tokenReq.Username)
 	if err != nil || user == nil {
+		if err == nil {
+			err = errors.New("user not found")
+		}
 		response.InternalServerError(w, "Invalid username", err)
 		return
 	}
 
 	passwordMatch, err := user.PasswordHash.Check(tokenReq.Password)
 	if err != nil || !passwordMatch {
+		if err == nil {
+			err = errors.New("password does not match")
+		}
 		response.InternalServerError(w, "Invalid password", err)
 		return
 	}

--- a/store/user_store.go
+++ b/store/user_store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"golang.org/x/crypto/bcrypt"
@@ -45,6 +46,12 @@ type User struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
+var AnonymousUser = &User{}
+
+func (u *User) IsAnonymous() bool {
+	return u == AnonymousUser
+}
+
 type PostgresUserStore struct {
 	db *sql.DB
 }
@@ -57,6 +64,7 @@ type UserStore interface {
 	CreateUser(*User) error
 	GetUserByName(username string) (*User, error)
 	UpdateUser(*User) error
+	GetUserToken(scope, tokenPlaintTextPassword string) (*User, error)
 }
 
 func (store *PostgresUserStore) CreateUser(user *User) error {
@@ -109,4 +117,30 @@ func (store *PostgresUserStore) UpdateUser(user *User) error {
 		return sql.ErrNoRows
 	}
 	return nil
+}
+
+func (store *PostgresUserStore) GetUserToken(scope, tokenPlaintTextPassword string) (*User, error) {
+	tokenHash := sha256.Sum256([]byte(tokenPlaintTextPassword))
+	query := "SELECT u.id, u.username, u.email, u.password_hash, u.bio, u.created_at, u.updated_at " +
+		"FROM users u INNER JOIN tokens t ON t.user_id = u.id WHERE t.hash = $1 AND t.scopes = $2 AND t.expired > $3"
+
+	user := &User{
+		PasswordHash: password{},
+	}
+	err := store.db.QueryRow(query, tokenHash[:], scope, time.Now()).Scan(
+		&user.Id,
+		&user.UserName,
+		&user.Email,
+		&user.PasswordHash.hash,
+		&user.Bio,
+		&user.CreatedAt,
+		&user.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
 }

--- a/store/user_store.go
+++ b/store/user_store.go
@@ -64,7 +64,7 @@ type UserStore interface {
 	CreateUser(*User) error
 	GetUserByName(username string) (*User, error)
 	UpdateUser(*User) error
-	GetUserToken(scope, tokenPlaintTextPassword string) (*User, error)
+	GetUserToken(scope, tokenPlaintextPassword string) (*User, error)
 }
 
 func (store *PostgresUserStore) CreateUser(user *User) error {
@@ -119,8 +119,8 @@ func (store *PostgresUserStore) UpdateUser(user *User) error {
 	return nil
 }
 
-func (store *PostgresUserStore) GetUserToken(scope, tokenPlaintTextPassword string) (*User, error) {
-	tokenHash := sha256.Sum256([]byte(tokenPlaintTextPassword))
+func (store *PostgresUserStore) GetUserToken(scope, tokenPlaintextPassword string) (*User, error) {
+	tokenHash := sha256.Sum256([]byte(tokenPlaintextPassword))
 	query := "SELECT u.id, u.username, u.email, u.password_hash, u.bio, u.created_at, u.updated_at " +
 		"FROM users u INNER JOIN tokens t ON t.user_id = u.id WHERE t.hash = $1 AND t.scopes = $2 AND t.expired > $3"
 

--- a/test.http
+++ b/test.http
@@ -61,3 +61,24 @@ GET http://localhost:1500/workouts/6
 
 ### Delete Workout
 DELETE http://localhost:1500/workouts/5
+
+### Register User
+POST http://localhost:1500/users
+Content-Type: application/json
+
+{
+  "username": "jack_marston",
+  "email": "jack.marston@example.com",
+  "password": "password12345",
+  "bio": "Fitness enthusiast and software developer"
+}
+
+
+### Authenticate User
+POST http://localhost:1500/tokens/authentication
+Content-Type: application/json
+
+{
+  "username": "jack_marston",
+  "password": "password12345"
+}


### PR DESCRIPTION
This pull request introduces several changes to enhance user authentication and token handling in the API. Key updates include improvements to error handling in token creation, the addition of a method for retrieving users by token, and updates to the test suite to include user registration and authentication scenarios.

### Authentication and Token Handling Enhancements:
* **Improved error handling in `HandleCreateToken`**: Added specific error messages for cases where a user is not found or the password does not match, using the `errors` package for more descriptive error reporting. (`api/token_handler.go`: [api/token_handler.goR42-R53](diffhunk://#diff-60525a9211812095b67afe1651e329328bebd5cbccc1018d2ca31c04c19f2193R42-R53))
* **New `GetUserToken` method in `UserStore`**: Introduced a method to retrieve a user based on a token's hash and scope, with additional SQL query logic for validating token expiration. (`store/user_store.go`: [[1]](diffhunk://#diff-a7ce9444905c8ee3ba6da418e99dca6b6d731122160acd3c03733f242b1515efR67) [[2]](diffhunk://#diff-a7ce9444905c8ee3ba6da418e99dca6b6d731122160acd3c03733f242b1515efR121-R146)

### Codebase Improvements:
* **Anonymous user handling**: Added a new `AnonymousUser` variable and `IsAnonymous` method to the `User` struct to simplify checks for unauthenticated users. (`store/user_store.go`: [store/user_store.goR49-R54](diffhunk://#diff-a7ce9444905c8ee3ba6da418e99dca6b6d731122160acd3c03733f242b1515efR49-R54))

### Test Suite Updates:
* **New test cases for user registration and authentication**: Added HTTP requests to test user registration and token-based authentication in the `test.http` file. (`test.http`: [test.httpR64-R84](diffhunk://#diff-10fff5894a63f52650d5f7764103a2d909131cee6f9c68ac46a26ff572787ec9R64-R84))

### Miscellaneous:
* **Dependency updates**: Imported the `errors` package in `api/token_handler.go` and the `crypto/sha256` package in `store/user_store.go` to support new functionality. (`api/token_handler.go`: [[1]](diffhunk://#diff-60525a9211812095b67afe1651e329328bebd5cbccc1018d2ca31c04c19f2193R5) `store/user_store.go`: [[2]](diffhunk://#diff-a7ce9444905c8ee3ba6da418e99dca6b6d731122160acd3c03733f242b1515efR4)