### PR TITLE
last touch before testing all endpoint

### DIFF
--- a/migrations/11_27_2025_user_id_alter.sql
+++ b/migrations/11_27_2025_user_id_alter.sql
@@ -1,0 +1,12 @@
+-- +goose up
+-- +goose statementbegin
+
+ALTER TABLE workout ADD COLUMN user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE;
+
+-- +goose statementend
+
+
+-- +goose down
+-- +goose statementbegin
+ALTER TABLE workout DROP COLUMN user_id;
+-- +goose statementend

--- a/response/response-helper.go
+++ b/response/response-helper.go
@@ -32,6 +32,7 @@ type WorkoutResponse struct {
 	UpdatedFields interface{} `json:"updated_fields,omitempty"`
 }
 
+// UserResponse contains user-specific response data
 type UserResponse struct {
 	ID       int    `json:"id"`
 	UserName string `json:"username"`
@@ -187,4 +188,17 @@ func UserUpdated(w http.ResponseWriter, user interface{}) {
 		logger.Printf("User updated")
 	}
 	Success(w, "User successfully updated", user)
+}
+
+func Forbidden(w http.ResponseWriter, sprintf string) {
+	if logger != nil {
+		logger.Printf("Forbidden: %s", sprintf)
+	}
+
+	resp := ErrorResponse{
+		Success: false,
+		Message: sprintf,
+		Error:   "Forbidden",
+	}
+	JSON(w, http.StatusForbidden, resp)
 }


### PR DESCRIPTION
This pull request introduces user authorization and ownership checks for workout-related actions, adds a `user_id` column to the `workout` table, and updates the codebase to enforce these changes. Key updates include middleware integration, database schema changes, and new helper methods for ownership validation.

### Authorization and Ownership Checks:

* [`api/workout_handler.go`](diffhunk://#diff-d2409321466d197303c9b9598c16bc554794b8368d404bf696be2957f2455aa2R63-R69): Added middleware to retrieve the current user and enforce that only logged-in users can create, update, or delete workouts. Ownership checks were implemented for update and delete operations to ensure only the workout owner can perform these actions. [[1]](diffhunk://#diff-d2409321466d197303c9b9598c16bc554794b8368d404bf696be2957f2455aa2R63-R69) [[2]](diffhunk://#diff-d2409321466d197303c9b9598c16bc554794b8368d404bf696be2957f2455aa2R148-R164) [[3]](diffhunk://#diff-d2409321466d197303c9b9598c16bc554794b8368d404bf696be2957f2455aa2R187-R202)

* [`response/response-helper.go`](diffhunk://#diff-be3201839d0cd8bed2669e6c2709f5ead1a0cc5369864015667a3ad28865c02bR192-R204): Added a new `Forbidden` response helper to handle unauthorized access attempts with appropriate HTTP status and error messages.

### Database Schema Changes:

* [`migrations/11_27_2025_user_id_alter.sql`](diffhunk://#diff-3097032c64b834be094a674815545e08e6ef142bbf855ba833a3acb200aef468R1-R12): Added a `user_id` column to the `workout` table with a foreign key constraint referencing the `users` table. This ensures workouts are associated with a specific user and cascade deletes when the user is deleted.

### Data Model Updates:

* [`store/workout_store.go`](diffhunk://#diff-285a9d34cf7a204af19b67728b174892458188e3b42d801adba3acaa3cc11bc2R18): Updated the `Workout` struct to include a `UserId` field. Modified the `CreateWorkout` query to include the `user_id` field and added a new `GetWorkoutOwner` method to fetch the owner of a workout by its ID. [[1]](diffhunk://#diff-285a9d34cf7a204af19b67728b174892458188e3b42d801adba3acaa3cc11bc2R18) [[2]](diffhunk://#diff-285a9d34cf7a204af19b67728b174892458188e3b42d801adba3acaa3cc11bc2L48-R52) [[3]](diffhunk://#diff-285a9d34cf7a204af19b67728b174892458188e3b42d801adba3acaa3cc11bc2R154-R166)

### Middleware Integration:

* [`api/workout_handler.go`](diffhunk://#diff-d2409321466d197303c9b9598c16bc554794b8368d404bf696be2957f2455aa2R10): Imported `middleware` to retrieve the current user from the request context, enabling user-specific logic in workout handlers.